### PR TITLE
QA pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # esri-proj-codes
 
-This module provides a method for looking up Well Known Text (WKT) representations of various projections. A projection can be found by providing an Esri projection code, and will result in the projection name and WKT being returned. 
+[![npm version](https://img.shields.io/npm/v/esri-proj-codes.svg?style=flat-square)](https://www.npmjs.com/package/esri-proj-codes)
+
+This module provides a method for looking up Well Known Text (WKT) representations of various projections. A projection can be found by providing an Esri projection code, and will result in the projection name and WKT being returned.
 
 ##  Usage
 
@@ -17,13 +19,13 @@ var codes = require('esri-proj-codes')
 var projInfo = codes.lookup('3857')
 ```
 
-## Source 
+## Source
 
-There are 3 sets of projection codes includes in this module. 
+There are 3 sets of projection codes includes in this module.
 
 * [Projected Projection Codes](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Projected_coordinate_systems/02r3000000vt000000/)
 * [Geographic Projection Codes](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Geographic_coordinate_systems/02r300000105000000/)
-* [Vertical Projection Codes](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Vertical_coordinate_systems/02r3000000rn000000/)  
+* [Vertical Projection Codes](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Vertical_coordinate_systems/02r3000000rn000000/)
 
 ## Resources
 

--- a/index.js
+++ b/index.js
@@ -1,18 +1,3 @@
-/*
-  Copyright 2015 Esri
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
- 
-      http://www.apache.org/licenses/LICENSE-2.0
- 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-*/
-
 var fs = require('fs')
 
 var projectedCodes = JSON.parse(fs.readFileSync(__dirname + '/lib/projected.json'))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esri-proj-codes",
   "version": "1.0.0",
-  "description": "A node.js module for projection code lookups",
+  "description": "Get a WKT representation from an Esri projection code.",
   "main": "index.js",
   "scripts": {
     "test": "standard && node test | tap-spec"

--- a/test/index.js
+++ b/test/index.js
@@ -1,18 +1,3 @@
-/*
-  Copyright 2015 Esri
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
- 
-      http://www.apache.org/licenses/LICENSE-2.0
- 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-*/
-
 var test = require('tape'),
  codes = require('../')
 


### PR DESCRIPTION
- License info is already at the root of the repo so I removed it from files, this is not a normal convention for open source projects anymore.
- Added a .gitignore to make sure `node_modules` is ignored.
- Added an npm version badge to display version & provide quick link to package on npm.
- Updated `package.json` description to be more terse.
