### PR TITLE
fix package.json license string

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "projections"
   ],
   "author": "Chris Helm",
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/Esri/esri-proj-codes/issues"
   },


### PR DESCRIPTION
just a small change to avoid an `npm install` nag.

@dmfenton, should we bump to `1.0.1` (for @substack's contribution)?
